### PR TITLE
Shift-JISデータ読み込みの後方互換性を追加

### DIFF
--- a/Common/Info/InfoAccount.cpp
+++ b/Common/Info/InfoAccount.cpp
@@ -107,9 +107,9 @@ DWORD CInfoAccount::GetDataSize(void)
 	dwRet += sizeof (m_dwLoginCount);
 	dwRet += ((m_adwCharID.size() + 1) * sizeof (DWORD));
 	dwRet += sizeof (m_nAdminLevel);
-	dwRet += (m_strAccount.GetLength () + 1);
-	dwRet += (m_strPassword.GetLength () + 1);
-	dwRet += (m_strMacAddr.GetLength () + 1);
+	dwRet += (m_strAccount.GetUtf8Length () + 1);
+	dwRet += (m_strPassword.GetUtf8Length () + 1);
+	dwRet += (m_strMacAddr.GetUtf8Length () + 1);
 
 	return dwRet;
 }
@@ -136,9 +136,9 @@ DWORD CInfoAccount::GetDataSizeNo(int nNo)
 	case 5:	dwRet = sizeof (m_dwLoginCount);							break;
 	case 6:	dwRet = ((m_adwCharID.size() + 1) * sizeof (DWORD));	break;
 	case 7:	dwRet = sizeof (m_nAdminLevel);								break;
-	case 8:	dwRet = (m_strAccount.GetLength () + 1);					break;
-	case 9:	dwRet = (m_strPassword.GetLength () + 1);					break;
-	case 10:dwRet = (m_strMacAddr.GetLength () + 1);					break;		/* アカウント登録MACアドレス */
+	case 8:	dwRet = (m_strAccount.GetUtf8Length () + 1);					break;
+	case 9:	dwRet = (m_strPassword.GetUtf8Length () + 1);					break;
+	case 10:dwRet = (m_strMacAddr.GetUtf8Length () + 1);					break;		/* アカウント登録MACアドレス */
 	}
 
 	return dwRet;
@@ -258,15 +258,15 @@ DWORD CInfoAccount::ReadElementData(
 	case 7:	pDst = (PBYTE)&m_nAdminLevel;		dwSize = sizeof (m_nAdminLevel);		break;
 	case 8:
 		m_strAccount = (LPCSTR)pSrc;
-		dwSize = m_strAccount.GetLength () + 1;
+		dwSize = (DWORD)(strlen ((LPCSTR)pSrc) + 1);
 		break;
 	case 9:
 		m_strPassword = (LPCSTR)pSrc;
-		dwSize = m_strPassword.GetLength () + 1;
+		dwSize = (DWORD)(strlen ((LPCSTR)pSrc) + 1);
 		break;
 	case 10:
 		m_strMacAddr = (LPCSTR)pSrc;
-		dwSize = m_strMacAddr.GetLength () + 1;
+		dwSize = (DWORD)(strlen ((LPCSTR)pSrc) + 1);
 		break;
 	}
 
@@ -422,9 +422,9 @@ PBYTE CInfoAccount::GetTmpData(DWORD &dwDataSize)
 	/* サイズを計算 */
 	dwDataSize += sizeof (m_dwAccountID);
 	dwDataSize += sizeof (m_dwIP);
-	dwDataSize += (m_strAccount.GetLength () + 1);
-	dwDataSize += (m_strPassword.GetLength () + 1);
-	dwDataSize += (m_strLastMacAddr.GetLength () + 1);
+	dwDataSize += (m_strAccount.GetUtf8Length () + 1);
+	dwDataSize += (m_strPassword.GetUtf8Length () + 1);
+	dwDataSize += (m_strLastMacAddr.GetUtf8Length () + 1);
 
 	pRet = ZeroNew (dwDataSize);
 	pDataTmp = pRet;

--- a/Common/Info/InfoCharBase.cpp
+++ b/Common/Info/InfoCharBase.cpp
@@ -353,9 +353,9 @@ DWORD CInfoCharBase::GetDataSize(void)
 	dwRet += sizeof (m_dwMaxSP);
 	dwRet += sizeof (m_clName);
 	dwRet += sizeof (m_clSpeak);
-	dwRet += (m_strCharName.GetLength () + 1);
-	dwRet += (m_strSpeak.GetLength () + 1);
-	dwRet += (m_strTalk.GetLength () + 1);
+	dwRet += (m_strCharName.GetUtf8Length () + 1);
+	dwRet += (m_strSpeak.GetUtf8Length () + 1);
+	dwRet += (m_strTalk.GetUtf8Length () + 1);
 	dwRet += ((m_adwItemID.size() + 1) * sizeof (DWORD));
 	dwRet += ((m_adwSkillID.size() + 1) * sizeof (DWORD));
 	dwRet += sizeof (m_sizeSearchDistance);		/* 策敵範囲 */
@@ -414,9 +414,9 @@ DWORD CInfoCharBase::GetDataSizeNo(int nNo)
 	case 28:	dwRet = sizeof (m_dwMotionTypeID);			break;
 	case 29:	dwRet = sizeof (m_clName);					break;
 	case 30:	dwRet = sizeof (m_clSpeak);					break;
-	case 31:	dwRet = (m_strCharName.	GetLength () + 1);	break;
-	case 32:	dwRet = (m_strSpeak.	GetLength () + 1);	break;
-	case 33:	dwRet = (m_strTalk.		GetLength () + 1);	break;
+	case 31:	dwRet = (m_strCharName.GetUtf8Length () + 1);	break;
+	case 32:	dwRet = (m_strSpeak.GetUtf8Length () + 1);	break;
+	case 33:	dwRet = (m_strTalk.GetUtf8Length () + 1);	break;
 	case 34:	dwRet = ((m_adwItemID.size() + 1) * sizeof (DWORD));	break;
 	case 35:	dwRet = ((m_adwSkillID.size() + 1) * sizeof (DWORD));	break;
 	case 36:	dwRet = sizeof (m_bBlock);					break;
@@ -677,15 +677,15 @@ DWORD CInfoCharBase::ReadElementData(
 	case 30:	pDst = (PBYTE)&m_clSpeak;				dwSize = sizeof (m_clSpeak);			break;
 	case 31:
 		m_strCharName = (LPCSTR)pSrc;
-		dwSize = m_strCharName.GetLength () + 1;
+		dwSize = (DWORD)(strlen ((LPCSTR)pSrc) + 1);
 		break;
 	case 32:
 		m_strSpeak = (LPCSTR)pSrc;
-		dwSize = m_strSpeak.GetLength () + 1;
+		dwSize = (DWORD)(strlen ((LPCSTR)pSrc) + 1);
 		break;
 	case 33:
 		m_strTalk = (LPCSTR)pSrc;
-		dwSize = m_strTalk.GetLength () + 1;
+		dwSize = (DWORD)(strlen ((LPCSTR)pSrc) + 1);
 		break;
 	case 34:
 		pTmp	= pSrc;
@@ -867,9 +867,9 @@ DWORD CInfoCharBase::GetSendDataSize(void)
 	dwRet += sizeof (m_dwMaxSP);
 	dwRet += sizeof (m_clName);
 	dwRet += sizeof (m_clSpeak);
-	dwRet += (m_strCharName.GetLength () + 1);
-	dwRet += (m_strSpeak.	GetLength () + 1);
-	dwRet += (m_strTalk.	GetLength () + 1);
+	dwRet += (m_strCharName.GetUtf8Length () + 1);
+	dwRet += (m_strSpeak.GetUtf8Length () + 1);
+	dwRet += (m_strTalk.GetUtf8Length () + 1);
 	dwRet += (m_abyMark.	GetSize () + 1);
 	dwRet += ((m_adwItemID.	GetSize () + 1) * sizeof (DWORD));
 	dwRet += ((m_adwSkillID.size() + 1) * sizeof (DWORD));

--- a/Common/Info/InfoDisable.cpp
+++ b/Common/Info/InfoDisable.cpp
@@ -81,7 +81,7 @@ DWORD CInfoDisable::GetDataSize(void)
 
 	dwRet = 0;
 	dwRet += sizeof (m_dwDisableID);				/* 拒否情報ID */
-	dwRet += (m_strMacAddress.GetLength () + 1);	/* MACアドレス */
+	dwRet += (m_strMacAddress.GetUtf8Length () + 1);	/* MACアドレス */
 
 	return dwRet;
 }
@@ -101,7 +101,7 @@ DWORD CInfoDisable::GetDataSizeNo(int nNo)
 
 	switch (nNo) {
 	case 0:		dwRet = sizeof (m_dwDisableID);				break;	/* 拒否情報ID */
-	case 1:		dwRet = (m_strMacAddress.GetLength () + 1);	break;	/* MACアドレス */
+	case 1:		dwRet = (m_strMacAddress.GetUtf8Length () + 1);	break;	/* MACアドレス */
 	}
 
 	return dwRet;
@@ -175,7 +175,7 @@ DWORD CInfoDisable::ReadElementData(
 	case 0:		pDst = (PBYTE)&m_dwDisableID;	dwSize = sizeof (m_dwDisableID);	break;	/* 拒否情報ID */
 	case 1:		/* MACアドレス */
 		m_strMacAddress = (LPCSTR)pSrc;
-		dwSize = m_strMacAddress.GetLength () + 1;
+		dwSize = (DWORD)(strlen ((LPCSTR)pSrc) + 1);
 		break;
 	}
 
@@ -198,7 +198,7 @@ DWORD CInfoDisable::GetSendDataSize(void)
 	DWORD dwRet;
 
 	dwRet = sizeof (m_dwDisableID)	+
-			(m_strMacAddress.GetLength () + 1);
+			(m_strMacAddress.GetUtf8Length () + 1);
 
 	return dwRet;
 }

--- a/Common/Info/InfoEfcBalloon.cpp
+++ b/Common/Info/InfoEfcBalloon.cpp
@@ -97,7 +97,7 @@ DWORD CInfoEfcBalloon::GetDataSize(void)
 			sizeof (m_dwListID)				+	/* 噴出し種別ID */
 			sizeof (m_dwAnimeID)			+	/* コマ番号 */
 			sizeof (m_dwSoundID)			+	/* 効果音ID */
-			(m_strName.GetLength () + 1)	+	/* 画像ID */
+			(m_strName.GetUtf8Length () + 1)	+	/* 画像ID */
 			sizeof (m_dwGrpID); 			 	/* 噴出し名 */
 
 	return dwRet;
@@ -124,7 +124,7 @@ DWORD CInfoEfcBalloon::GetDataSizeNo(int nNo)
 	case 4:		dwRet = sizeof (m_dwAnimeID);			break;	/* コマ番号 */
 	case 5:		dwRet = sizeof (m_dwSoundID);			break;	/* 効果音ID */
 	case 6:		dwRet = sizeof (m_dwGrpID);				break;	/* 画像ID */
-	case 7:		dwRet = (m_strName.GetLength () + 1);	break;	/* 噴出し名 */
+	case 7:		dwRet = (m_strName.GetUtf8Length () + 1);	break;	/* 噴出し名 */
 	}
 
 	return dwRet;
@@ -210,7 +210,7 @@ DWORD CInfoEfcBalloon::ReadElementData(
 	case 6:		pDst = (PBYTE)&m_dwGrpID;			dwSize = sizeof (m_dwGrpID);		break;	/* 画像ID */
 	case 7: 																				  	/* 噴出し名 */
 		m_strName = (LPCSTR)pSrc;
-		dwSize = m_strName.GetLength () + 1;
+		dwSize = (DWORD)(strlen ((LPCSTR)pSrc) + 1);
 		break;
 	}
 

--- a/Common/Info/InfoEffect.cpp
+++ b/Common/Info/InfoEffect.cpp
@@ -149,7 +149,7 @@ DWORD CInfoEffect::GetDataSize(void)
 			sizeof (m_dwEffectID)	+
 			sizeof (m_dwSoundID)	+
 			sizeof (m_dwGrpIDMain)	+
-			(m_strName.GetLength () + 1);
+			(m_strName.GetUtf8Length () + 1);
 
 	if (m_byAnimeCount == 0) {
 		goto Exit;
@@ -189,7 +189,7 @@ DWORD CInfoEffect::GetDataSizeNo(int nNo)
 	case 3:		dwRet = sizeof (m_bLoop);				break;	/* ループ判定 */
 	case 4:		dwRet = sizeof (m_bLoopSound);			break;	/* ループ時に効果音を再生する */
 	case 5:		dwRet = sizeof (m_dwGrpIDMain);			break;	/* 画像メインID */
-	case 6:		dwRet = (m_strName.GetLength () + 1);	break;	/* エフェクト名 */
+	case 6:		dwRet = (m_strName.GetUtf8Length () + 1);	break;	/* エフェクト名 */
 	default:
 		nCount = m_paAnimeInfo->size();
 		for (i = 0; i < nCount; i ++) {
@@ -308,7 +308,7 @@ DWORD CInfoEffect::ReadElementData(
 	case 5:	pDst = (PBYTE)&m_dwGrpIDMain;	dwSize = sizeof (m_dwGrpIDMain);	break;	/* 画像メインID */
 	case 6: 																		  	/* エフェクト名 */
 		m_strName = (LPCSTR)pSrc;
-		dwSize = m_strName.GetLength () + 1;
+		dwSize = (DWORD)(strlen ((LPCSTR)pSrc) + 1);
 		break;
 	default:
 		pSrcTmp	= pSrc;
@@ -363,7 +363,7 @@ DWORD CInfoEffect::GetSendDataSize(void)
 			sizeof (m_dwSoundID)	+
 			sizeof (m_dwGrpIDMain)	+
 			sizeof (m_byAnimeCount)	+
-			(m_strName.GetLength () + 1);
+			(m_strName.GetUtf8Length () + 1);
 
 	if (m_byAnimeCount == 0) {
 		goto Exit;

--- a/Common/Info/InfoFileList.cpp
+++ b/Common/Info/InfoFileList.cpp
@@ -159,8 +159,8 @@ DWORD CInfoFileList::GetSendDataSize(void)
 	for (i = 0; i < nCount; i ++) {
 		pInfo = GetPtr (i);
 		dwRet += sizeof (pInfo->dwFileSize);				/* ファイルサイズ */
-		dwRet += (pInfo->strMD5.GetLength () + 1);			/* MD5ハッシュ */
-		dwRet += (pInfo->strFileName.GetLength () + 1);		/* ファイル名 */
+		dwRet += (pInfo->strMD5.GetUtf8Length () + 1);			/* MD5ハッシュ */
+		dwRet += (pInfo->strFileName.GetUtf8Length () + 1);		/* ファイル名 */
 	}
 	dwRet += sizeof (DWORD);
 

--- a/Common/Info/InfoFishing.cpp
+++ b/Common/Info/InfoFishing.cpp
@@ -90,7 +90,7 @@ DWORD CInfoFishing::GetDataSize(void)
 
 	dwRet += sizeof (m_dwFishingID);		/* 釣りID */
 	dwRet += sizeof (m_nAverage);			/* 釣れる確率 */
-	dwRet += (m_strName.GetLength () + 1);	/* 釣り場名 */
+	dwRet += (m_strName.GetUtf8Length () + 1);	/* 釣り場名 */
 	dwRet += sizeof (int);					/* 釣り情報パラメータ数 */
 	/* 釣り情報パラメータ */
 	dwRet += (nCount * sizeof (DWORD));		/* アイテム種別ID */
@@ -117,7 +117,7 @@ DWORD CInfoFishing::GetDataSizeNo(int nNo)
 	switch (nNo) {
 	case 0:		dwRet = sizeof (m_dwFishingID);			break;	/* 釣りID */
 	case 1:		dwRet = sizeof (m_nAverage);			break;	/* 釣れる確率 */
-	case 2:		dwRet = (m_strName.GetLength () + 1);	break;	/* 釣り場名 */
+	case 2:		dwRet = (m_strName.GetUtf8Length () + 1);	break;	/* 釣り場名 */
 	case 3:		dwRet = nCount * sizeof (int);			break;	/* 釣り情報パラメータ数 */
 	case 4:		dwRet = nCount * sizeof (DWORD);		break;	/* アイテム種別ID */
 	case 5:		dwRet = nCount * sizeof (int);			break;	/* 釣りきる確率 */
@@ -217,7 +217,7 @@ DWORD CInfoFishing::ReadElementData(
 	case 1:		pDst = (PBYTE)&m_nAverage;			break;	/* 釣れる確率 */
 	case 2:		/* 釣り場名 */
 		m_strName = (LPCSTR)pSrc;
-		dwSize = m_strName.GetLength () + 1;
+		dwSize = (DWORD)(strlen ((LPCSTR)pSrc) + 1);
 		break;
 	case 3:		/* 釣り情報パラメータ数 */
 		CopyMemory ((PBYTE)&nCount, pSrc, dwSize);

--- a/Common/Info/InfoItem.cpp
+++ b/Common/Info/InfoItem.cpp
@@ -111,7 +111,7 @@ DWORD CInfoItem::GetDataSize(void)
 	dwRet += sizeof (m_nPosZ);				/* 落ちている高さ(0が地面) */
 	dwRet += sizeof (m_ptPos);				/* 落ちている座標 */
 	dwRet += sizeof (m_ptBackPack);			/* バックパック内の位置 */
-	dwRet += (m_strName.GetLength () + 1);	/* アイテム名 */
+	dwRet += (m_strName.GetUtf8Length () + 1);	/* アイテム名 */
 
 	return dwRet;
 }
@@ -140,7 +140,7 @@ DWORD CInfoItem::GetDataSizeNo(int nNo)
 	case 7:		dwRet = sizeof (m_nPosZ);				break;	/* 落ちている高さ(0が地面) */
 	case 8:		dwRet = sizeof (m_ptPos);				break;	/* 落ちている座標 */
 	case 9:		dwRet = sizeof (m_ptBackPack);			break;	/* バックパック内の位置 */
-	case 10:	dwRet = (m_strName.GetLength () + 1);	break;	/* アイテム名 */
+	case 10:	dwRet = (m_strName.GetUtf8Length () + 1);	break;	/* アイテム名 */
 	case 11:	dwRet = sizeof (m_dwDropSoundID);		break;	/* 落ちたときの効果音ID */
 	}
 
@@ -234,7 +234,7 @@ DWORD CInfoItem::ReadElementData(
 	case 9:		pDst = (PBYTE)&m_ptBackPack;		dwSize = sizeof (m_ptBackPack);		break;	/* バックパック内の位置 */
 	case 10:	/* アイテム名 */
 		m_strName = (LPCSTR)pSrc;
-		dwSize = m_strName.GetLength () + 1;
+		dwSize = (DWORD)(strlen ((LPCSTR)pSrc) + 1);
 		break;
 	case 11:	pDst = (PBYTE)&m_dwDropSoundID;		dwSize = sizeof (m_dwDropSoundID);	break;	/* 落ちたときの効果音ID */
 	}
@@ -268,7 +268,7 @@ DWORD CInfoItem::GetSendDataSize(void)
 			sizeof (m_nPosZ)			+
 			sizeof (m_ptPos)			+
 			sizeof (m_ptBackPack)		+
-			(m_strName.GetLength () + 1);
+			(m_strName.GetUtf8Length () + 1);
 
 	return dwRet;
 }

--- a/Common/Info/InfoItemType/InfoItemTypeBase.cpp
+++ b/Common/Info/InfoItemType/InfoItemTypeBase.cpp
@@ -127,7 +127,7 @@ DWORD CInfoItemTypeBase::GetDataSize(void)
 	dwRet += sizeof (m_dwGrpID);			/* 地面にある時の画像ID */
 	dwRet += sizeof (m_dwIconGrpID);		/* バックパック内の画像ID */
 	dwRet += sizeof (m_dwDropSoundID);		/* 落ちたときの効果音ID */
-	dwRet += (m_strName.GetLength () + 1);	/* アイテム名 */
+	dwRet += (m_strName.GetUtf8Length () + 1);	/* アイテム名 */
 	dwRet += sizeof (m_dwUseEffectID);		/* 使った時に再生するエフェクトID */
 	dwRet += sizeof (m_dwUseSoundID);		/* 使った時に再生する効果音ID */
 	dwRet += sizeof (m_dwWeaponInfoID);		/* 武器情報ID */
@@ -161,7 +161,7 @@ DWORD CInfoItemTypeBase::GetDataSizeNo(int nNo)
 	case 5:		dwRet = sizeof (m_dwItemTypeID);		break;	/* アイテム種別ID */
 	case 6:		dwRet = sizeof (m_dwGrpID);				break;	/* 地面にある時の画像ID */
 	case 7:		dwRet = sizeof (m_dwIconGrpID);			break;	/* バックパック内の画像ID */
-	case 8:		dwRet = (m_strName.GetLength () + 1);	break;	/* アイテム名 */
+	case 8:		dwRet = (m_strName.GetUtf8Length () + 1);	break;	/* アイテム名 */
 	case 9:		dwRet = sizeof (m_dwDropSoundID);		break;	/* 落ちたときの効果音ID */
 	case 10:	dwRet = sizeof (m_wGrpIDMain);			break;	/* 画像IDメイン */
 	case 11:	dwRet = sizeof (m_wGrpIDSub);			break;	/* 画像IDサブ */
@@ -269,7 +269,7 @@ DWORD CInfoItemTypeBase::ReadElementData(
 	case 7:		pDst = (PBYTE)&m_dwIconGrpID;		dwSize = sizeof (m_dwIconGrpID);	break;	/* バックパック内の画像ID */
 	case 8:		/* アイテム名 */
 		m_strName = (LPCSTR)pSrc;
-		dwSize = m_strName.GetLength () + 1;
+		dwSize = (DWORD)(strlen ((LPCSTR)pSrc) + 1);
 		break;
 	case 9:		pDst = (PBYTE)&m_dwDropSoundID;		dwSize = sizeof (m_dwDropSoundID);		break;	/* 落ちたときの効果音ID */
 	case 10:	pDst = (PBYTE)&m_wGrpIDMain;		dwSize = sizeof (m_wGrpIDMain);			break;	/* 画像IDメイン */
@@ -314,7 +314,7 @@ DWORD CInfoItemTypeBase::GetSendDataSize(void)
 			sizeof (m_wGrpIDSub)			+
 			sizeof (m_dwUseEffectID)		+	/* 使った時に再生するエフェクトID */
 			sizeof (m_dwUseSoundID)			+	/* 使った時に再生する効果音ID */
-			(m_strName.GetLength () + 1)	+
+			(m_strName.GetUtf8Length () + 1)	+
 			sizeof (m_dwWeaponInfoID)		+	/* 武器情報ID */
 			sizeof (m_dwValue)				+	/* 攻撃力 */
 			sizeof (m_dwMoveWait)			+	/* 速度 */

--- a/Common/Info/InfoItemWeapon.cpp
+++ b/Common/Info/InfoItemWeapon.cpp
@@ -92,7 +92,7 @@ DWORD CInfoItemWeapon::GetDataSize(void)
 	dwRet += sizeof (m_dwMotionType);									/* 使用可能な攻撃モーション */
 	dwRet += sizeof (m_dwMotionTypeStand);								/* 戦闘モード中の立ちモーション */
 	dwRet += sizeof (m_dwMotionTypeWalk);								/* 戦闘モード中のすり足モーション */
-	dwRet += (m_strName.GetLength () + 1);								/* 武器種別名 */
+	dwRet += (m_strName.GetUtf8Length () + 1);								/* 武器種別名 */
 	dwRet += ((m_adwEffectIDAtack.size() + 1) * sizeof (DWORD));	/* 通常攻撃時のエフェクトID */
 	dwRet += ((m_adwEffectIDCritical.size() + 1) * sizeof (DWORD));	/* クリティカル時のエフェクトID */
 
@@ -117,7 +117,7 @@ DWORD CInfoItemWeapon::GetDataSizeNo(int nNo)
 	case 1:		dwRet = sizeof (m_dwMotionType);									break;	/* 使用可能な攻撃モーション */
 	case 2:		dwRet = sizeof (m_dwMotionTypeStand);								break;	/* 戦闘モード中の立ちモーション */
 	case 3:		dwRet = sizeof (m_dwMotionTypeWalk);								break;	/* 戦闘モード中のすり足モーション */
-	case 4:		dwRet = (m_strName.GetLength () + 1);								break;	/* 武器種別名 */
+	case 4:		dwRet = (m_strName.GetUtf8Length () + 1);								break;	/* 武器種別名 */
 	case 5:		dwRet = ((m_adwEffectIDAtack.size() + 1) * sizeof (DWORD));		break;	/* 通常攻撃時のエフェクトID数 */
 	case 6:		dwRet = ((m_adwEffectIDCritical.size() + 1) * sizeof (DWORD));	break;	/* クリティカル時のエフェクトID数 */
 
@@ -225,7 +225,7 @@ DWORD CInfoItemWeapon::ReadElementData(
 	case 3:		pDst = (PBYTE)&m_dwMotionTypeWalk;			break;	/* 戦闘モード中のすり足モーション */
 	case 4:		/* 武器種別名 */
 		m_strName = (LPCSTR)pSrc;
-		dwSize = m_strName.GetLength () + 1;
+		dwSize = (DWORD)(strlen ((LPCSTR)pSrc) + 1);
 		break;
 	case 5:		/* 通常攻撃時のエフェクトID */
 		pTmp	= pSrc;

--- a/Common/Info/InfoMapBase.cpp
+++ b/Common/Info/InfoMapBase.cpp
@@ -320,7 +320,7 @@ DWORD CInfoMapBase::GetDataSize(void)
 	dwRet += ((m_sizeMap.cx * sizeof (WORD)) * m_sizeMap.cy);
 	dwRet += ((m_sizeMap.cx * sizeof (WORD)) * m_sizeMap.cy);
 	dwRet += ((m_sizeMap.cx * sizeof (WORD)) * m_sizeMap.cy);
-	dwRet += (m_strMapName.GetLength () + 1);
+	dwRet += (m_strMapName.GetUtf8Length () + 1);
 	if (m_pLibInfoMapEvent) {
 		dwRet += m_pLibInfoMapEvent->GetDataSize ();
 	}
@@ -355,7 +355,7 @@ DWORD CInfoMapBase::GetDataSizeNo(int nNo)
 	case 7:	dwRet = (m_sizeMap.cx * sizeof (WORD)) * m_sizeMap.cy;	break;
 	case 8:	dwRet = (m_sizeMap.cx * sizeof (WORD)) * m_sizeMap.cy;	break;
 	case 9:	dwRet = (m_sizeMap.cx * sizeof (WORD)) * m_sizeMap.cy;	break;
-	case 10:dwRet = m_strMapName.GetLength () + 1;					break;
+	case 10:dwRet = m_strMapName.GetUtf8Length () + 1;					break;
 	case 11:
 		if (m_pLibInfoMapEvent) {
 			dwRet = m_pLibInfoMapEvent->GetDataSize ();
@@ -485,7 +485,7 @@ DWORD CInfoMapBase::ReadElementData(
 		break;
 	case 10:
 		m_strMapName = (LPCSTR)pSrc;
-		dwSize = m_strMapName.GetLength () + 1;
+		dwSize = (DWORD)(strlen ((LPCSTR)pSrc) + 1);
 		break;
 	case 11:
 		if (m_pLibInfoMapEvent) {
@@ -975,7 +975,7 @@ DWORD CInfoMapBase::GetSendDataSize(void)
 	dwRet += ((m_sizeMap.cx * sizeof (WORD)) * m_sizeMap.cy);
 	dwRet += ((m_sizeMap.cx * sizeof (WORD)) * m_sizeMap.cy);
 	dwRet += ((m_sizeMap.cx * sizeof (WORD)) * m_sizeMap.cy);
-	dwRet += (m_strMapName.GetLength () + 1);
+	dwRet += (m_strMapName.GetUtf8Length () + 1);
 	if (m_pLibInfoMapEvent) {
 		dwRet += m_pLibInfoMapEvent->GetSendDataSize ();
 	}

--- a/Common/Info/InfoMapObject.cpp
+++ b/Common/Info/InfoMapObject.cpp
@@ -138,7 +138,7 @@ DWORD CInfoMapObject::GetDataSizeNo(int nNo)
 	case 2:		dwRet = sizeof (m_nHideY);				break;		/* 隠れる上からのマス数 */
 	case 3:		dwRet = sizeof (m_sizeGrp);				break;		/* 画像サイズ */
 	case 4:		dwRet = sizeof (m_bHit);				break;		/* 当たり判定 */
-	case 5:		dwRet = m_strName.GetLength () + 1;		break;		/* オブジェクト名 */
+	case 5:		dwRet = m_strName.GetUtf8Length () + 1;		break;		/* オブジェクト名 */
 	case 6:		dwRet = m_sizeGrp.cx * m_sizeGrp.cy;	break;		/* 当たり判定データ */
 	case 7:		dwRet = sizeof (nTmp);					break;		/* オブジェクトアニメ数 */
 	case 8:		dwRet = sizeof (BYTE) * nTmp;			break;		/* 待ち時間(×１０ミリ秒) */
@@ -264,7 +264,7 @@ DWORD CInfoMapObject::ReadElementData(
 	case 4:		pDst = (PBYTE)&m_bHit;			dwSize = sizeof (m_bHit);			break;		/* 当たり判定 */
 	case 5:		/* オブジェクト名 */
 		m_strName = (LPCSTR)pSrc;
-		dwSize = m_strName.GetLength () + 1;
+		dwSize = (DWORD)(strlen ((LPCSTR)pSrc) + 1);
 		break;
 	case 6:		/* 当たり判定データ */
 		SAFE_DELETE_ARRAY (m_pHit);

--- a/Common/Info/InfoMotionType.cpp
+++ b/Common/Info/InfoMotionType.cpp
@@ -83,7 +83,7 @@ DWORD CInfoMotionType::GetDataSize(void)
 
 	dwRet = sizeof (m_dwMotionTypeID)	+
 			sizeof (m_wGrpIDSub)		+
-			(m_strName.GetLength () + 1);
+			(m_strName.GetUtf8Length () + 1);
 
 	return dwRet;
 }
@@ -104,7 +104,7 @@ DWORD CInfoMotionType::GetDataSizeNo(int nNo)
 	switch (nNo) {
 	case 0:		dwRet = sizeof (m_dwMotionTypeID);		break;		/* モーション種別ID */
 	case 1:		dwRet = sizeof (m_wGrpIDSub);			break;		/* プレビュー用グラフィックIDサブ */
-	case 2:		dwRet = (m_strName.GetLength () + 1);	break;		/* モーション種別名 */
+	case 2:		dwRet = (m_strName.GetUtf8Length () + 1);	break;		/* モーション種別名 */
 	}
 
 	return dwRet;
@@ -180,7 +180,7 @@ DWORD CInfoMotionType::ReadElementData(
 	case 1:		pDst = (PBYTE)&m_wGrpIDSub;			dwSize = sizeof (m_wGrpIDSub);		break;		/* プレビュー用グラフィックIDサブ */
 	case 2:		/* モーション種別名 */
 		m_strName = (LPCSTR)pSrc;
-		dwSize = m_strName.GetLength () + 1;
+		dwSize = (DWORD)(strlen ((LPCSTR)pSrc) + 1);
 		break;
 	}
 

--- a/Common/Info/InfoSkill/InfoSkillBase.cpp
+++ b/Common/Info/InfoSkill/InfoSkillBase.cpp
@@ -99,7 +99,7 @@ DWORD CInfoSkillBase::GetDataSize(void)
 	dwRet += sizeof (m_nTypeMain);			/* スキル種別(メイン) */
 	dwRet += sizeof (m_nTypeSub);			/* スキル種別(サブ) */
 	dwRet += sizeof (m_nUse);				/* 使用制限 */
-	dwRet += (m_strName.GetLength () + 1);	/* スキル名 */
+	dwRet += (m_strName.GetUtf8Length () + 1);	/* スキル名 */
 	dwRet += GetDerivationSize ();			/* 派生データ */
 
 	return dwRet;
@@ -125,7 +125,7 @@ DWORD CInfoSkillBase::GetDataSizeNo(int nNo)
 	case 3:	dwRet = sizeof (m_nTypeMain);			break;	/* スキル種別(メイン) */
 	case 4:	dwRet = sizeof (m_nTypeSub);			break;	/* スキル種別(サブ) */
 	case 5:	dwRet = sizeof (m_nUse);				break;	/* 使用制限 */
-	case 6:	dwRet = (m_strName.GetLength () + 1);	break;	/* スキル名 */
+	case 6:	dwRet = (m_strName.GetUtf8Length () + 1);	break;	/* スキル名 */
 	case 7:	dwRet = GetDerivationSize ();			break;	/* 派生データ */
 	}
 
@@ -215,7 +215,7 @@ DWORD CInfoSkillBase::ReadElementData(
 	case 5: pDst = (PBYTE)&m_nUse;		dwSize = sizeof (m_nUse);		break;	/* 使用制限 */
 	case 6:		/* スキル名 */
 		m_strName = (LPCSTR)pSrc;
-		dwSize = m_strName.GetLength () + 1;
+		dwSize = (DWORD)(strlen ((LPCSTR)pSrc) + 1);
 		break;
 	case 7:		/* 派生データ */
 		dwSize = ReadDerivationData (pSrc);
@@ -289,7 +289,7 @@ DWORD CInfoSkillBase::GetSendDataSize(void)
 	dwRet += sizeof (m_nTypeMain);			/* スキル種別(メイン) */
 	dwRet += sizeof (m_nTypeSub);			/* スキル種別(サブ) */
 	dwRet += sizeof (m_nUse);				/* 使用制限 */
-	dwRet += (m_strName.GetLength () + 1);	/* スキル名 */
+	dwRet += (m_strName.GetUtf8Length () + 1);	/* スキル名 */
 
 	return dwRet;
 }

--- a/Common/Info/InfoTalkEvent/InfoTalkEventBase.cpp
+++ b/Common/Info/InfoTalkEvent/InfoTalkEventBase.cpp
@@ -87,7 +87,7 @@ DWORD CInfoTalkEventBase::GetDataSize(void)
 	dwRet += sizeof (m_nEventType);					/* 会話イベント種別 */
 	dwRet += sizeof (m_nPage);						/* 所属ページ番号 */
 	dwRet += sizeof (m_dwData);						/* バイナリデータ */
-	dwRet += (m_strText.GetLength () + 1);			/* 文字列データ */
+	dwRet += (m_strText.GetUtf8Length () + 1);			/* 文字列データ */
 
 	return dwRet;
 }
@@ -109,7 +109,7 @@ DWORD CInfoTalkEventBase::GetDataSizeNo(int nNo)
 	case 0:	dwRet = sizeof (m_nEventType);			break;	/* 会話イベント種別 */
 	case 1:	dwRet = sizeof (m_nPage);				break;	/* 所属ページ番号 */
 	case 2:	dwRet = sizeof (m_dwData);				break;	/* バイナリデータ */
-	case 3:	dwRet = m_strText.GetLength () + 1;		break;	/* 文字列データ */
+	case 3:	dwRet = m_strText.GetUtf8Length () + 1;		break;	/* 文字列データ */
 	}
 
 	return dwRet;
@@ -187,7 +187,7 @@ DWORD CInfoTalkEventBase::ReadElementData(
 	case 2: pDst = (PBYTE)&m_dwData;			dwSize = sizeof (m_dwData);				break;		/* バイナリデータ */
 	case 3:				/* 文字列データ */
 		m_strText = (LPCSTR)pSrc;
-		dwSize = m_strText.GetLength () + 1;
+		dwSize = (DWORD)(strlen ((LPCSTR)pSrc) + 1);
 		break;
 	}
 
@@ -213,7 +213,7 @@ DWORD CInfoTalkEventBase::GetSendDataSize(void)
 	dwRet += sizeof (m_nEventType);					/* 会話イベント種別 */
 	dwRet += sizeof (m_nPage);						/* 所属ページ番号 */
 	dwRet += sizeof (m_dwData);						/* バイナリデータ */
-	dwRet += (m_strText.GetLength () + 1);			/* 文字列データ */
+	dwRet += (m_strText.GetUtf8Length () + 1);			/* 文字列データ */
 
 	return dwRet;
 }

--- a/Common/Info/InfoTalkEvent/InfoTalkEventMENU.cpp
+++ b/Common/Info/InfoTalkEvent/InfoTalkEventMENU.cpp
@@ -106,7 +106,7 @@ DWORD CInfoTalkEventMENU::GetDataSize(void)
 	for (i = 0; i < nCount; i ++) {
 		pInfo = m_aMenuInfo[i];
 		dwRet += sizeof (int);						/* ジャンプ先ページ番号 */
-		dwRet += (pInfo->strName.GetLength () + 1);	/* 項目名 */
+		dwRet += (pInfo->strName.GetUtf8Length () + 1);	/* 項目名 */
 	}
 
 	return dwRet;
@@ -142,7 +142,7 @@ DWORD CInfoTalkEventMENU::GetDataSizeNo(int nNo)
 	case 2:			/* 項目名 */
 		for (i = 0; i < nCount; i ++) {
 			pInfo = m_aMenuInfo[i];
-			dwRet += (pInfo->strName.GetLength () + 1);
+			dwRet += (pInfo->strName.GetUtf8Length () + 1);
 		}
 		break;
 	}

--- a/Common/Packet/ADMIN/PacketADMIN_CHAR_RENEW_ACCOUNT.cpp
+++ b/Common/Packet/ADMIN/PacketADMIN_CHAR_RENEW_ACCOUNT.cpp
@@ -53,8 +53,8 @@ void CPacketADMIN_CHAR_RENEW_ACCOUNT::Make(
 	dwSize = sizeof (PACKETBASE) +
 			 sizeof (bDisable) +
 			 sizeof (pInfoAccount->m_dwAccountID) +
-			 		(pInfoAccount->m_strAccount.GetLength () + 1) +
-			 		(pInfoAccount->m_strPassword.GetLength () + 1);
+			 		(pInfoAccount->m_strAccount.GetUtf8Length () + 1) +
+			 		(pInfoAccount->m_strPassword.GetUtf8Length () + 1);
 	if (pszMacAddress) {
 		dwSize += strlen (pszMacAddress);
 	}

--- a/Common/Packet/ADMIN/PacketADMIN_CHAR_RES_ACCOUNT.cpp
+++ b/Common/Packet/ADMIN/PacketADMIN_CHAR_RES_ACCOUNT.cpp
@@ -53,8 +53,8 @@ void CPacketADMIN_CHAR_RES_ACCOUNT::Make(
 	dwSize = sizeof (PACKETBASE) +
 			 sizeof (dwIP) +
 			 sizeof (pInfoAccount->m_dwAccountID) +
-			 		(pInfoAccount->m_strAccount.GetLength () + 1) +
-			 		(pInfoAccount->m_strPassword.GetLength () + 1) +
+			 		(pInfoAccount->m_strAccount.GetUtf8Length () + 1) +
+			 		(pInfoAccount->m_strPassword.GetUtf8Length () + 1) +
 			(strlen (pszMacAddress) + 1);
 
 	pData = new BYTE[dwSize];

--- a/Common/myLib/myString.cpp
+++ b/Common/myLib/myString.cpp
@@ -297,6 +297,16 @@ CmyString::operator LPCSTR()
 #endif
 }
 
+int CmyString::GetUtf8Length() const
+{
+#ifdef _UNICODE
+        UpdateUtf8Cache ();
+        return m_strUtf8Cache.GetLength ();
+#else
+        return m_strString.GetLength ();
+#endif
+}
+
 
 /* ========================================================================= */
 /* 関数名       :CmyString::CompareNoCase                                                                                */

--- a/Common/myLib/myString.h
+++ b/Common/myLib/myString.h
@@ -177,6 +177,8 @@ public:
                         operator LPCSTR         () const;                                               /* UTF-8キャスト */
                         operator LPCSTR         ();                                                     /* UTF-8キャスト */
 
+        int             GetUtf8Length   () const;                                      /* UTF-8文字列長を取得 */
+
         int             CompareNoCase   (LPCSTR pszSrc) const;                 /* 文字列比較(大文字小文字区別無し) */
         int             CompareNoCase   (LPCTSTR pszSrc) const;                /* 文字列比較(大文字小文字区別無し) */
 

--- a/Common/myLib/myString.h
+++ b/Common/myLib/myString.h
@@ -14,6 +14,10 @@
 #include <atlstr.h>
 #include <atlconv.h>
 
+#ifndef MB_ERR_INVALID_CHARS
+#define MB_ERR_INVALID_CHARS 0x00000008
+#endif
+
 #ifdef __cplusplus
 inline CString Utf8ToTString(LPCSTR pszSrc)
 {
@@ -22,13 +26,40 @@ inline CString Utf8ToTString(LPCSTR pszSrc)
         if (pszSrc == NULL) {
                 return strResult;
         }
-        int nLen = MultiByteToWideChar (CP_UTF8, 0, pszSrc, -1, NULL, 0);
-        if (nLen <= 0) {
-                return strResult;
+
+        struct SCandidate
+        {
+                UINT    codePage;
+                DWORD   dwFlags;
+        };
+
+        const SCandidate aCandidate[] = {
+                { CP_UTF8, MB_ERR_INVALID_CHARS },
+                { 932,     0 },
+                { CP_ACP,  0 },
+        };
+
+        for (int i = 0; i < (int)(sizeof (aCandidate) / sizeof (aCandidate[0])); ++i) {
+                const UINT  codePage = aCandidate[i].codePage;
+                const DWORD dwFlags  = aCandidate[i].dwFlags;
+                int nLen = MultiByteToWideChar (codePage, dwFlags, pszSrc, -1, NULL, 0);
+                if (nLen <= 0) {
+                        continue;
+                }
+                LPTSTR pszBuffer = strResult.GetBuffer (nLen);
+                if (pszBuffer == NULL) {
+                        strResult.ReleaseBuffer (0);
+                        continue;
+                }
+                int nRet = MultiByteToWideChar (codePage, dwFlags, pszSrc, -1, pszBuffer, nLen);
+                if (nRet > 0) {
+                        strResult.ReleaseBuffer ();
+                        return strResult;
+                }
+                strResult.ReleaseBuffer (0);
+                strResult.Empty ();
         }
-        LPTSTR pszBuffer = strResult.GetBuffer (nLen);
-        MultiByteToWideChar (CP_UTF8, 0, pszSrc, -1, pszBuffer, nLen);
-        strResult.ReleaseBuffer ();
+
         return strResult;
 #else
         CString strResult;


### PR DESCRIPTION
## Summary
- UTF-8変換に失敗した場合にShift-JISおよびACPへフォールバックするよう`Utf8ToTString`を更新しました
- `MB_ERR_INVALID_CHARS`未定義環境向けのフォールバック定義を追加しました

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d73b571bb4832f89ad9a4987ab0600