### PR TITLE
Web管理: マップオブジェクト配置ビューのプロトタイプ追加

### DIFF
--- a/SboSvr/webroot/app.js
+++ b/SboSvr/webroot/app.js
@@ -17,9 +17,173 @@ const roleResultEl = document.getElementById("role-result");
 const roleCheckboxContainer = document.getElementById("role-checkboxes");
 const roleResetButton = document.getElementById("role-reset");
 
+const mapObjectMapSelect = document.getElementById("map-object-map");
+const mapObjectFilterSelect = document.getElementById("map-object-filter");
+const mapObjectSummaryEl = document.getElementById("map-object-summary");
+const mapObjectTableBody = document.getElementById("map-object-table-body");
+const mapObjectGridEl = document.getElementById("map-object-grid");
+const mapObjectSelectedLabel = document.getElementById("map-object-selected-label");
+const mapObjectForm = document.getElementById("map-object-form");
+const mapObjectNameInput = document.getElementById("map-object-name");
+const mapObjectTypeSelect = document.getElementById("map-object-type");
+const mapObjectLayerSelect = document.getElementById("map-object-layer");
+const mapObjectXInput = document.getElementById("map-object-x");
+const mapObjectYInput = document.getElementById("map-object-y");
+const mapObjectRespawnInput = document.getElementById("map-object-respawn");
+const mapObjectNotesInput = document.getElementById("map-object-notes");
+const mapObjectClearButton = document.getElementById("map-object-clear");
+const mapObjectDeleteButton = document.getElementById("map-object-delete");
+const mapObjectFeedbackEl = document.getElementById("map-object-feedback");
+
 const POLL_INTERVAL_MS = 30000;
 let serverTimerId = null;
 let cachedRoles = [];
+
+const MAP_OBJECT_TYPE_OPTIONS = [
+  { value: "interactable", label: "インタラクト" },
+  { value: "trigger", label: "トリガー" },
+  { value: "decoration", label: "装飾" },
+  { value: "spawn", label: "スポーン" }
+];
+
+const mockMapObjectDataset = [
+  {
+    id: "fld_001",
+    name: "初心者の草原",
+    width: 18,
+    height: 12,
+    weather: "晴れ",
+    recommendedLevel: "1-5",
+    safeArea: true,
+    description: "チュートリアルとイベントガイド用に利用するフィールドマップです。",
+    objects: [
+      {
+        id: "fld_001_obj_001",
+        name: "復帰ポータル",
+        type: "interactable",
+        layer: "interaction",
+        x: 3,
+        y: 5,
+        respawn: 0,
+        notes: "クリックで拠点に戻る"
+      },
+      {
+        id: "fld_001_obj_002",
+        name: "補給商人ソラ",
+        type: "spawn",
+        layer: "ground",
+        x: 10,
+        y: 6,
+        respawn: 600,
+        notes: "夜間は出現しない"
+      },
+      {
+        id: "fld_001_obj_003",
+        name: "古びた宝箱",
+        type: "trigger",
+        layer: "ground",
+        x: 14,
+        y: 2,
+        respawn: 1800,
+        notes: "チュートリアル完了後に開封可能"
+      }
+    ]
+  },
+  {
+    id: "dng_010",
+    name: "忘却の洞窟 B1",
+    width: 14,
+    height: 10,
+    weather: "地下（暗闇）",
+    recommendedLevel: "25-30",
+    safeArea: false,
+    description: "中盤ダンジョンの入り口層。トリガー系の罠が多数配置されます。",
+    objects: [
+      {
+        id: "dng_010_obj_004",
+        name: "起動装置:封印門",
+        type: "trigger",
+        layer: "interaction",
+        x: 6,
+        y: 4,
+        respawn: 0,
+        notes: "対応スイッチを押すまで開かない"
+      },
+      {
+        id: "dng_010_obj_005",
+        name: "採掘ポイント",
+        type: "interactable",
+        layer: "ground",
+        x: 2,
+        y: 8,
+        respawn: 900,
+        notes: "鉱石を採取すると 15 分後に復活"
+      },
+      {
+        id: "dng_010_obj_006",
+        name: "監視スプライト",
+        type: "decoration",
+        layer: "sky",
+        x: 11,
+        y: 3,
+        respawn: null,
+        notes: "エフェクト用の飾り"
+      }
+    ]
+  },
+  {
+    id: "tow_201",
+    name: "天空庭園",
+    width: 16,
+    height: 12,
+    weather: "快晴",
+    recommendedLevel: "40",
+    safeArea: true,
+    description: "高レベル帯の休憩エリア。季節イベントの展示物を配置します。",
+    objects: [
+      {
+        id: "tow_201_obj_007",
+        name: "祝福の像",
+        type: "decoration",
+        layer: "ground",
+        x: 7,
+        y: 5,
+        respawn: null,
+        notes: "シーズン限定の装飾"
+      },
+      {
+        id: "tow_201_obj_008",
+        name: "転送装置",
+        type: "interactable",
+        layer: "interaction",
+        x: 4,
+        y: 9,
+        respawn: 0,
+        notes: "首都へ移動"
+      },
+      {
+        id: "tow_201_obj_009",
+        name: "イベント案内人リナ",
+        type: "spawn",
+        layer: "ground",
+        x: 12,
+        y: 7,
+        respawn: 300,
+        notes: "条件: イベントフラグ ON"
+      }
+    ]
+  }
+];
+
+const mapObjectState = {
+  maps: mockMapObjectDataset,
+  selectedMapId: mockMapObjectDataset.length ? mockMapObjectDataset[0].id : null,
+  selectedObjectId: null,
+  filterType: "all",
+  previewSelection: null
+};
+
+
 
 const DEFAULT_ROUTE = "server-dashboard";
 const views = document.querySelectorAll("[data-view]");
@@ -383,6 +547,481 @@ function handleRoleReset() {
   renderRoleOptions();
 }
 
+function initializeMapObjectView() {
+  if (!mapObjectMapSelect) {
+    return;
+  }
+  populateMapOptions();
+  populateMapObjectTypeSelect(mapObjectFilterSelect, true);
+  populateMapObjectTypeSelect(mapObjectTypeSelect, false);
+
+  if (mapObjectState.selectedMapId) {
+    mapObjectMapSelect.value = mapObjectState.selectedMapId;
+  } else if (mapObjectMapSelect.options.length) {
+    mapObjectState.selectedMapId = mapObjectMapSelect.options[0].value;
+  }
+
+  if (mapObjectFilterSelect) {
+    mapObjectFilterSelect.value = mapObjectState.filterType;
+  }
+
+  applyObjectToForm(null, getSelectedMapData());
+  renderMapComponents();
+  setMapObjectFeedback("", null);
+}
+
+function populateMapOptions() {
+  if (!mapObjectMapSelect) {
+    return;
+  }
+  mapObjectMapSelect.innerHTML = "";
+  if (!mapObjectState.maps.length) {
+    const option = document.createElement("option");
+    option.value = "";
+    option.textContent = "マップデータなし";
+    mapObjectMapSelect.appendChild(option);
+    return;
+  }
+  mapObjectState.maps.forEach((map) => {
+    const option = document.createElement("option");
+    option.value = map.id;
+    option.textContent = `${map.name} (ID: ${map.id})`;
+    mapObjectMapSelect.appendChild(option);
+  });
+}
+
+function populateMapObjectTypeSelect(select, includeAll) {
+  if (!select) {
+    return;
+  }
+  select.innerHTML = "";
+  if (includeAll) {
+    const allOption = document.createElement("option");
+    allOption.value = "all";
+    allOption.textContent = "すべて";
+    select.appendChild(allOption);
+  }
+  MAP_OBJECT_TYPE_OPTIONS.forEach((item, index) => {
+    const option = document.createElement("option");
+    option.value = item.value;
+    option.textContent = item.label;
+    if (!includeAll && index === 0) {
+      option.selected = true;
+    }
+    select.appendChild(option);
+  });
+}
+
+function getSelectedMapData() {
+  return mapObjectState.maps.find((map) => map.id === mapObjectState.selectedMapId) || null;
+}
+
+function getMapObjectTypeLabel(type) {
+  const found = MAP_OBJECT_TYPE_OPTIONS.find((item) => item.value === type);
+  return found ? found.label : type;
+}
+
+function formatRespawnValue(value) {
+  if (value === null || value === undefined) {
+    return "-";
+  }
+  if (value === 0) {
+    return "即時";
+  }
+  if (!Number.isFinite(value) || value < 0) {
+    return "-";
+  }
+  if (value % 60 === 0) {
+    const minutes = value / 60;
+    return `${minutes}分`;
+  }
+  return `${value}秒`;
+}
+
+function renderMapSummary(map) {
+  if (!mapObjectSummaryEl) {
+    return;
+  }
+  if (!map) {
+    mapObjectSummaryEl.textContent = "管理対象のマップが選択されていません";
+    mapObjectSummaryEl.title = "";
+    return;
+  }
+  const safety = map.safeArea ? "安全エリア" : "PvP 可能";
+  mapObjectSummaryEl.textContent = `${map.name} / ID: ${map.id} / サイズ: ${map.width}×${map.height} / ${safety} / 推奨レベル: ${map.recommendedLevel} / オブジェクト数: ${map.objects.length}`;
+  mapObjectSummaryEl.title = map.description || map.name;
+}
+
+function renderMapObjectTable(map) {
+  if (!mapObjectTableBody) {
+    return;
+  }
+  mapObjectTableBody.innerHTML = "";
+  if (!map) {
+    const row = document.createElement("tr");
+    const cell = document.createElement("td");
+    cell.colSpan = 6;
+    cell.textContent = "マップが選択されていません";
+    row.appendChild(cell);
+    mapObjectTableBody.appendChild(row);
+    return;
+  }
+
+  const filtered = map.objects.filter((object) => {
+    if (mapObjectState.filterType === "all") {
+      return true;
+    }
+    return object.type === mapObjectState.filterType;
+  });
+
+  if (!filtered.length) {
+    const row = document.createElement("tr");
+    const cell = document.createElement("td");
+    cell.colSpan = 6;
+    cell.textContent = "表示できるオブジェクトがありません";
+    row.appendChild(cell);
+    mapObjectTableBody.appendChild(row);
+    return;
+  }
+
+  filtered
+    .slice()
+    .sort((a, b) => {
+      if (a.y === b.y) {
+        return a.x - b.x;
+      }
+      return a.y - b.y;
+    })
+    .forEach((object) => {
+      const row = document.createElement("tr");
+      row.dataset.objectId = object.id;
+      row.tabIndex = 0;
+      if (object.id === mapObjectState.selectedObjectId) {
+        row.classList.add("is-selected");
+      }
+
+      const nameCell = document.createElement("td");
+      nameCell.textContent = object.name;
+      const typeCell = document.createElement("td");
+      typeCell.textContent = getMapObjectTypeLabel(object.type);
+      const layerCell = document.createElement("td");
+      layerCell.textContent = object.layer;
+      const xCell = document.createElement("td");
+      xCell.textContent = object.x.toString();
+      const yCell = document.createElement("td");
+      yCell.textContent = object.y.toString();
+      const respawnCell = document.createElement("td");
+      respawnCell.textContent = formatRespawnValue(object.respawn);
+
+      row.appendChild(nameCell);
+      row.appendChild(typeCell);
+      row.appendChild(layerCell);
+      row.appendChild(xCell);
+      row.appendChild(yCell);
+      row.appendChild(respawnCell);
+
+      row.addEventListener("click", () => {
+        selectMapObject(object.id);
+      });
+      row.addEventListener("keydown", (event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          selectMapObject(object.id);
+        }
+      });
+
+      mapObjectTableBody.appendChild(row);
+    });
+}
+
+function renderMapPreview(map) {
+  if (!mapObjectGridEl) {
+    return;
+  }
+  mapObjectGridEl.innerHTML = "";
+  if (!map) {
+    const empty = document.createElement("div");
+    empty.className = "empty-message";
+    empty.textContent = "マップが選択されていません";
+    mapObjectGridEl.style.gridTemplateColumns = "repeat(1, minmax(80px, 1fr))";
+    mapObjectGridEl.appendChild(empty);
+    return;
+  }
+
+  mapObjectGridEl.style.gridTemplateColumns = `repeat(${Math.max(map.width, 1)}, minmax(28px, 1fr))`;
+
+  const occupantMap = new Map();
+  map.objects.forEach((object) => {
+    occupantMap.set(`${object.x},${object.y}`, object);
+  });
+
+  const preview = mapObjectState.previewSelection;
+
+  for (let y = 0; y < map.height; y += 1) {
+    for (let x = 0; x < map.width; x += 1) {
+      const key = `${x},${y}`;
+      const occupant = occupantMap.get(key) || null;
+      const cellButton = document.createElement("button");
+      cellButton.type = "button";
+      cellButton.className = "map-object-cell";
+      cellButton.dataset.x = x.toString();
+      cellButton.dataset.y = y.toString();
+      cellButton.setAttribute("role", "gridcell");
+      cellButton.setAttribute("aria-label", `X: ${x}, Y: ${y}`);
+
+      if (occupant) {
+        cellButton.classList.add("has-object");
+        cellButton.title = `${occupant.name} (${getMapObjectTypeLabel(occupant.type)})`;
+        const mark = document.createElement("span");
+        mark.textContent = "●";
+        cellButton.appendChild(mark);
+        if (occupant.id === mapObjectState.selectedObjectId) {
+          cellButton.classList.add("is-selected");
+        }
+      } else if (preview && preview.x === x && preview.y === y) {
+        cellButton.classList.add("is-selected");
+      }
+
+      cellButton.addEventListener("click", () => {
+        handleMapCellClick(x, y, occupant ? occupant.id : null);
+      });
+
+      mapObjectGridEl.appendChild(cellButton);
+    }
+  }
+}
+
+function setMapObjectFeedback(message, type) {
+  if (!mapObjectFeedbackEl) {
+    return;
+  }
+  mapObjectFeedbackEl.textContent = message || "";
+  mapObjectFeedbackEl.className = "result-message";
+  if (type) {
+    mapObjectFeedbackEl.classList.add(type);
+  }
+}
+
+function clampCoordinate(value, max) {
+  if (max < 0) {
+    return 0;
+  }
+  return Math.max(0, Math.min(max, value));
+}
+
+function applyObjectToForm(object, map) {
+  if (!mapObjectForm) {
+    return;
+  }
+
+  const typeDefault = MAP_OBJECT_TYPE_OPTIONS[0]?.value || "";
+  const selectedMap = map || getSelectedMapData();
+  const maxX = selectedMap ? selectedMap.width - 1 : 0;
+  const maxY = selectedMap ? selectedMap.height - 1 : 0;
+
+  if (object) {
+    mapObjectNameInput.value = object.name || "";
+    mapObjectTypeSelect.value = object.type || typeDefault;
+    mapObjectLayerSelect.value = object.layer || "ground";
+    mapObjectXInput.value = clampCoordinate(object.x, maxX);
+    mapObjectYInput.value = clampCoordinate(object.y, maxY);
+    mapObjectRespawnInput.value = object.respawn === null || object.respawn === undefined ? "" : object.respawn;
+    mapObjectNotesInput.value = object.notes || "";
+    mapObjectSelectedLabel.textContent = `選択中: ${object.name} (ID: ${object.id})`;
+    if (mapObjectDeleteButton) {
+      mapObjectDeleteButton.disabled = false;
+    }
+  } else {
+    const preview = mapObjectState.previewSelection;
+    mapObjectNameInput.value = "";
+    mapObjectTypeSelect.value = mapObjectTypeSelect.options.length ? mapObjectTypeSelect.options[0].value : typeDefault;
+    mapObjectLayerSelect.value = "ground";
+    mapObjectXInput.value = clampCoordinate(preview ? preview.x : 0, maxX);
+    mapObjectYInput.value = clampCoordinate(preview ? preview.y : 0, maxY);
+    mapObjectRespawnInput.value = "";
+    mapObjectNotesInput.value = "";
+    mapObjectSelectedLabel.textContent = "選択中: 新規配置";
+    if (mapObjectDeleteButton) {
+      mapObjectDeleteButton.disabled = true;
+    }
+  }
+}
+
+function renderMapComponents() {
+  const map = getSelectedMapData();
+  renderMapSummary(map);
+  renderMapObjectTable(map);
+  renderMapPreview(map);
+}
+
+function selectMapObject(objectId) {
+  const map = getSelectedMapData();
+  if (!map) {
+    return;
+  }
+  if (!objectId) {
+    mapObjectState.selectedObjectId = null;
+    mapObjectState.previewSelection = null;
+    applyObjectToForm(null, map);
+    renderMapComponents();
+    return;
+  }
+  const target = map.objects.find((item) => item.id === objectId);
+  if (!target) {
+    mapObjectState.selectedObjectId = null;
+    applyObjectToForm(null, map);
+    renderMapComponents();
+    return;
+  }
+  mapObjectState.selectedObjectId = objectId;
+  mapObjectState.previewSelection = { x: target.x, y: target.y };
+  applyObjectToForm(target, map);
+  renderMapComponents();
+}
+
+function handleMapSelectChange() {
+  mapObjectState.selectedMapId = mapObjectMapSelect ? mapObjectMapSelect.value : null;
+  mapObjectState.selectedObjectId = null;
+  mapObjectState.previewSelection = null;
+  setMapObjectFeedback("", null);
+  const map = getSelectedMapData();
+  applyObjectToForm(null, map);
+  renderMapComponents();
+}
+
+function handleMapFilterChange() {
+  mapObjectState.filterType = mapObjectFilterSelect ? mapObjectFilterSelect.value : "all";
+  renderMapObjectTable(getSelectedMapData());
+}
+
+function handleMapCellClick(x, y, objectId) {
+  const map = getSelectedMapData();
+  if (!map) {
+    return;
+  }
+  if (objectId) {
+    selectMapObject(objectId);
+    return;
+  }
+  mapObjectState.previewSelection = { x, y };
+  mapObjectState.selectedObjectId = null;
+  applyObjectToForm(null, map);
+  mapObjectXInput.value = x;
+  mapObjectYInput.value = y;
+  renderMapComponents();
+  setMapObjectFeedback(`座標 (${x}, ${y}) を選択しました`, null);
+}
+
+function generateMapObjectId(mapId) {
+  const random = Math.floor(Math.random() * 46656).toString(36).padStart(3, "0");
+  const stamp = Date.now().toString(36).slice(-4);
+  return `${mapId}_${stamp}${random}`;
+}
+
+function handleMapObjectFormSubmit(event) {
+  event.preventDefault();
+  const map = getSelectedMapData();
+  if (!map) {
+    setMapObjectFeedback("マップを選択してください", "error");
+    return;
+  }
+
+  const name = mapObjectNameInput.value.trim();
+  const type = mapObjectTypeSelect.value;
+  const layer = mapObjectLayerSelect.value;
+  const x = Number(mapObjectXInput.value);
+  const y = Number(mapObjectYInput.value);
+  const respawnRaw = mapObjectRespawnInput.value.trim();
+  const respawn = respawnRaw === "" ? null : Number(respawnRaw);
+  const notes = mapObjectNotesInput.value.trim();
+
+  if (!name) {
+    setMapObjectFeedback("表示名を入力してください", "error");
+    return;
+  }
+  if (Number.isNaN(x) || Number.isNaN(y)) {
+    setMapObjectFeedback("座標には数値を入力してください", "error");
+    return;
+  }
+  if (x < 0 || y < 0 || x >= map.width || y >= map.height) {
+    setMapObjectFeedback("座標がマップの範囲外です", "error");
+    return;
+  }
+  if (respawn !== null && (Number.isNaN(respawn) || respawn < 0)) {
+    setMapObjectFeedback("リスポーン時間が不正です", "error");
+    return;
+  }
+
+  const existingIndex = map.objects.findIndex((item) => item.id === mapObjectState.selectedObjectId);
+
+  if (existingIndex >= 0) {
+    const target = map.objects[existingIndex];
+    target.name = name;
+    target.type = type;
+    target.layer = layer;
+    target.x = x;
+    target.y = y;
+    target.respawn = respawn;
+    target.notes = notes;
+    mapObjectState.previewSelection = { x, y };
+    setMapObjectFeedback("オブジェクト情報を更新しました", "success");
+  } else {
+    const newId = generateMapObjectId(map.id);
+    map.objects.push({
+      id: newId,
+      name,
+      type,
+      layer,
+      x,
+      y,
+      respawn,
+      notes
+    });
+    mapObjectState.selectedObjectId = newId;
+    mapObjectState.previewSelection = { x, y };
+    setMapObjectFeedback("新しいオブジェクトを配置しました", "success");
+  }
+
+  renderMapComponents();
+  if (mapObjectState.selectedObjectId) {
+    selectMapObject(mapObjectState.selectedObjectId);
+  } else {
+    applyObjectToForm(null, map);
+  }
+}
+
+function handleMapObjectClear() {
+  const map = getSelectedMapData();
+  mapObjectState.selectedObjectId = null;
+  mapObjectState.previewSelection = null;
+  applyObjectToForm(null, map);
+  renderMapComponents();
+  setMapObjectFeedback("選択をクリアしました", null);
+}
+
+function handleMapObjectDelete() {
+  const map = getSelectedMapData();
+  if (!map) {
+    setMapObjectFeedback("マップを選択してください", "error");
+    return;
+  }
+  if (!mapObjectState.selectedObjectId) {
+    setMapObjectFeedback("削除するオブジェクトを選択してください", "error");
+    return;
+  }
+  const index = map.objects.findIndex((item) => item.id === mapObjectState.selectedObjectId);
+  if (index === -1) {
+    setMapObjectFeedback("対象のオブジェクトが見つかりません", "error");
+    return;
+  }
+  const removed = map.objects.splice(index, 1)[0];
+  mapObjectState.selectedObjectId = null;
+  mapObjectState.previewSelection = null;
+  applyObjectToForm(null, map);
+  renderMapComponents();
+  setMapObjectFeedback(`オブジェクト「${removed.name}」を削除しました`, "success");
+}
+
 function getValidRoute(route) {
   if (!route) {
     return DEFAULT_ROUTE;
@@ -449,6 +1088,23 @@ window.addEventListener("load", () => {
   });
 
   loadRoles();
+
+  if (mapObjectMapSelect) {
+    initializeMapObjectView();
+    mapObjectMapSelect.addEventListener("change", handleMapSelectChange);
+  }
+  if (mapObjectFilterSelect) {
+    mapObjectFilterSelect.addEventListener("change", handleMapFilterChange);
+  }
+  if (mapObjectForm) {
+    mapObjectForm.addEventListener("submit", handleMapObjectFormSubmit);
+  }
+  if (mapObjectClearButton) {
+    mapObjectClearButton.addEventListener("click", handleMapObjectClear);
+  }
+  if (mapObjectDeleteButton) {
+    mapObjectDeleteButton.addEventListener("click", handleMapObjectDelete);
+  }
 
   if (reloadButton) {
     reloadButton.addEventListener("click", () => {

--- a/SboSvr/webroot/index.html
+++ b/SboSvr/webroot/index.html
@@ -264,14 +264,97 @@
       </section>
     </div>
     <div class="view" data-view="map-objects">
-      <section class="card placeholder-card">
-        <h2>マップオブジェクト配置（プレースホルダー）</h2>
-        <p>マップ上のオブジェクト配置・更新を行う予定の画面です。</p>
-        <ul>
-          <li>マップ座標ビューア</li>
-          <li>オブジェクト一覧とドラッグ&amp;ドロップ配置</li>
-          <li>配置ログと承認フロー</li>
-        </ul>
+      <section class="card" id="map-object-browser">
+        <h2>マップオブジェクト配置</h2>
+        <p class="card-description">
+          MFC 版 <code>DlgAdminMapObject</code> のワークフローを Web で再現する試験実装です。マップを選択すると、現在配置されているオブジェクト一覧と配置状況を確認できます。
+        </p>
+        <div class="map-object-controls">
+          <label class="form-field compact">
+            <span>マップ</span>
+            <select id="map-object-map" name="mapId"></select>
+          </label>
+          <label class="form-field compact">
+            <span>オブジェクト種別</span>
+            <select id="map-object-filter" name="objectType"></select>
+          </label>
+          <div class="map-object-summary" id="map-object-summary" aria-live="polite"></div>
+        </div>
+        <div class="table-wrapper">
+          <table class="data-table" id="map-object-table" aria-describedby="map-object-summary">
+            <thead>
+              <tr>
+                <th scope="col">名称</th>
+                <th scope="col">種別</th>
+                <th scope="col">レイヤー</th>
+                <th scope="col">X</th>
+                <th scope="col">Y</th>
+                <th scope="col">リスポーン</th>
+              </tr>
+            </thead>
+            <tbody id="map-object-table-body">
+              <tr>
+                <td colspan="6">マップを選択してください。</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+      <section class="card" id="map-object-editor">
+        <h2>配置プレビューと編集</h2>
+        <p class="card-description">座標グリッドをクリックすると、該当セルに新規オブジェクトを配置できます。既存オブジェクトを選択すると詳細を編集できます。</p>
+        <div class="map-object-selected" id="map-object-selected-label" aria-live="polite">選択中: 新規配置</div>
+        <div class="map-object-preview">
+          <div class="map-object-grid" id="map-object-grid" role="grid" aria-label="マップ配置グリッド"></div>
+          <div class="map-object-legend">
+            <span class="legend-item"><span class="legend-marker"></span>空きセル</span>
+            <span class="legend-item"><span class="legend-marker has-object"></span>オブジェクトあり</span>
+            <span class="legend-item"><span class="legend-marker is-selected"></span>選択位置</span>
+          </div>
+        </div>
+        <form id="map-object-form" class="map-object-form" novalidate>
+          <div class="form-grid compact">
+            <label class="form-field">
+              <span>表示名</span>
+              <input type="text" id="map-object-name" name="name" required maxlength="48" autocomplete="off" />
+            </label>
+            <label class="form-field">
+              <span>種別</span>
+              <select id="map-object-type" name="type" required></select>
+            </label>
+            <label class="form-field">
+              <span>レイヤー</span>
+              <select id="map-object-layer" name="layer" required>
+                <option value="ground">地形レイヤー</option>
+                <option value="decoration">装飾レイヤー</option>
+                <option value="interaction">インタラクトレイヤー</option>
+                <option value="sky">空レイヤー</option>
+              </select>
+            </label>
+            <label class="form-field coordinate">
+              <span>座標 X</span>
+              <input type="number" id="map-object-x" name="x" min="0" required />
+            </label>
+            <label class="form-field coordinate">
+              <span>座標 Y</span>
+              <input type="number" id="map-object-y" name="y" min="0" required />
+            </label>
+            <label class="form-field">
+              <span>リスポーン (秒)</span>
+              <input type="number" id="map-object-respawn" name="respawn" min="0" max="86400" step="30" />
+            </label>
+          </div>
+          <label class="form-field">
+            <span>メモ</span>
+            <textarea id="map-object-notes" name="notes" rows="3" maxlength="140"></textarea>
+          </label>
+          <div class="form-actions">
+            <button type="submit" class="button primary" id="map-object-save">配置を保存</button>
+            <button type="button" class="button secondary" id="map-object-clear">選択をクリア</button>
+            <button type="button" class="button danger" id="map-object-delete" disabled>削除</button>
+          </div>
+        </form>
+        <div id="map-object-feedback" class="result-message" role="status"></div>
       </section>
     </div>
     <div class="view" data-view="item-types">

--- a/SboSvr/webroot/styles.css
+++ b/SboSvr/webroot/styles.css
@@ -210,7 +210,10 @@ main {
 
 .form-field input[type="text"],
 .form-field input[type="email"],
-.form-field input[type="password"] {
+.form-field input[type="password"],
+.form-field input[type="number"],
+.form-field select,
+.form-field textarea {
   padding: 0.6rem 0.75rem;
   border-radius: 8px;
   border: 1px solid rgba(148, 163, 184, 0.35);
@@ -222,6 +225,25 @@ main {
 .form-field input:focus {
   outline: 2px solid rgba(96, 165, 250, 0.8);
   outline-offset: 2px;
+}
+
+.form-field textarea {
+  resize: vertical;
+  min-height: 120px;
+}
+
+.form-field.compact span {
+  font-size: 0.9rem;
+  opacity: 0.85;
+}
+
+.form-grid.compact {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.85rem;
+}
+
+.form-field.coordinate input {
+  font-variant-numeric: tabular-nums;
 }
 
 .roles-field {
@@ -325,6 +347,167 @@ main {
 
 .button.secondary {
   background-color: rgba(148, 163, 184, 0.4);
+}
+
+.button.danger {
+  background-color: rgba(248, 113, 113, 0.35);
+}
+
+.button.danger:hover,
+.button.danger:focus-visible {
+  background-color: rgba(248, 113, 113, 0.55);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 520px;
+  font-size: 0.92rem;
+}
+
+.data-table thead {
+  background-color: rgba(15, 23, 42, 0.75);
+}
+
+.data-table th,
+.data-table td {
+  padding: 0.55rem 0.75rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  text-align: left;
+}
+
+.data-table tbody tr {
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.data-table tbody tr:hover {
+  background-color: rgba(96, 165, 250, 0.1);
+}
+
+.data-table tbody tr.is-selected {
+  background-color: rgba(96, 165, 250, 0.25);
+}
+
+.map-object-controls {
+  display: grid;
+  gap: 0.85rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: end;
+}
+
+.map-object-summary {
+  font-size: 0.9rem;
+  line-height: 1.6;
+  opacity: 0.8;
+  min-height: 2.2rem;
+}
+
+.map-object-selected {
+  font-weight: 600;
+  font-size: 1rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 8px;
+  background-color: rgba(96, 165, 250, 0.12);
+  color: #bfdbfe;
+}
+
+.map-object-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.map-object-grid {
+  display: grid;
+  gap: 4px;
+  background-color: rgba(15, 23, 42, 0.6);
+  padding: 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  max-height: 420px;
+  overflow: auto;
+}
+
+.map-object-grid .empty-message {
+  grid-column: 1 / -1;
+  padding: 1rem;
+  text-align: center;
+  opacity: 0.75;
+}
+
+.map-object-cell {
+  position: relative;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background-color: rgba(30, 41, 59, 0.7);
+  padding: 0;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: transform 0.1s ease, border-color 0.1s ease, background-color 0.1s ease;
+}
+
+.map-object-cell:hover,
+.map-object-cell:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(96, 165, 250, 0.45);
+}
+
+.map-object-cell.has-object {
+  background: linear-gradient(145deg, rgba(96, 165, 250, 0.35), rgba(59, 130, 246, 0.25));
+}
+
+.map-object-cell.is-selected {
+  outline: 2px solid rgba(250, 204, 21, 0.9);
+  outline-offset: -2px;
+}
+
+.map-object-cell span {
+  position: absolute;
+  inset: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: rgba(248, 250, 252, 0.85);
+}
+
+.map-object-legend {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+  opacity: 0.85;
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.legend-marker {
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  background-color: rgba(30, 41, 59, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  display: inline-block;
+}
+
+.legend-marker.has-object {
+  background: linear-gradient(145deg, rgba(96, 165, 250, 0.35), rgba(59, 130, 246, 0.25));
+}
+
+.legend-marker.is-selected {
+  background-color: rgba(250, 204, 21, 0.45);
+  border-color: rgba(250, 204, 21, 0.8);
 }
 
 .result-message {


### PR DESCRIPTION
## Summary
- Web管理UIにマップオブジェクト配置カードと編集フォームを追加
- 配置グリッドやオブジェクト一覧を操作できるモックデータロジックを実装
- テーブルおよびプレビュー向けのスタイルを拡充して操作感を改善

## Testing
- 未実施（静的アセットのため）

------
https://chatgpt.com/codex/tasks/task_e_68dba7548e9c832fac9188c54c53c347